### PR TITLE
Added liquibase support adding #49 new indexes to changelog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         classpath "org.grails.plugins:hibernate5:${gormVersion}"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:3.3.2"
         classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
+        classpath 'org.grails.plugins:database-migration:3.1.0'
     }
 }
 
@@ -73,6 +74,14 @@ configurations {
     }
 }
 
+sourceSets {
+    main {
+        resources {
+            srcDir 'grails-app/migrations'
+        }
+    }
+}
+
 dependencies {
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     compile "org.springframework.boot:spring-boot-starter-logging"
@@ -120,13 +129,18 @@ dependencies {
     // Third-party plugins
     compile "org.grails.plugins:external-config:2.0.0"
     compile 'org.grails.plugins:csv:1.0.1'
-    runtime "mysql:mysql-connector-java:8.0.23"
+    runtime "mysql:mysql-connector-java:8.0.22"
 
     // ALA deps
     compile "au.org.ala:ala-logger:1.4.1"
     compile "org.grails.plugins:ala-auth:3.2.3" //, noCache
     compile "org.grails.plugins:ala-bootstrap3:3.2.3" //, noCache
     compile "org.grails.plugins:ala-admin-plugin:2.2" //, noCache
+
+    // db-migration
+    // In newer versions use 'implementation'
+    compile 'org.liquibase:liquibase-core:3.10.3'
+    compile "org.grails.plugins:database-migration:3.1.0"
 }
 
 webdriverBinaries {

--- a/grails-app/conf/application.groovy
+++ b/grails-app/conf/application.groovy
@@ -70,3 +70,16 @@ grails.hibernate.osiv.readonly = false
 
 // We need to override the System message data dir path (assumes it will be logger-service via ${Metadata.current.getApplicationName()})
 ala.admin.systemMessage.path = "/data/logger/config"
+
+grails.plugin.databasemigration.changelogFileName = 'changelog.xml'
+grails.plugin.databasemigration.updateOnStart = true
+grails.plugin.databasemigration.updateOnStartFileName = 'changelog.xml'
+
+// We can limit the context where the db migration run
+// https://liquibase.org/blog/contexts-vs-labels
+// typically to skip during test or dev
+// grails.plugin.databasemigration.updateOnStartContexts = ['context1,context2']
+
+// If extra logs are needed for liquibase
+// logging.level.liquibase=on
+// logging.level.liquibase.executor=on

--- a/grails-app/migrations/changelog.xml
+++ b/grails-app/migrations/changelog.xml
@@ -1,0 +1,107 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.6.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.6.xsd">
+
+    <!-- required indexes for log_event to allow faster/more efficient sorting. -->
+
+    <changeSet author="ALA Dev Team" id="1">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="log_event" columnNames="month" />
+            </not>
+        </preConditions>
+        <createIndex indexName="month_idx" tableName="log_event">
+            <column name="month"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="ALA Dev Team" id="2">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="log_event" columnNames="log_event_type_id" />
+            </not>
+        </preConditions>
+        <createIndex indexName="log_event_type_id_idx" tableName="log_event">
+            <column name="log_event_type_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="ALA Dev Team" id="3">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="log_event" columnNames="log_source_type_id" />
+            </not>
+        </preConditions>
+        <createIndex indexName="log_source_type_id_idx" tableName="log_event">
+            <column name="log_source_type_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="ALA Dev Team" id="4">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="log_event" columnNames="log_reason_type_id" />
+            </not>
+        </preConditions>
+        <createIndex indexName="log_reason_type_id_idx" tableName="log_event">
+            <column name="log_reason_type_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="ALA Dev Team" id="5">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="log_event" columnNames="user_email" />
+            </not>
+        </preConditions>
+        <createIndex indexName="user_email_idx" tableName="log_event">
+            <column name="user_email"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="ALA Dev Team" id="6">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="log_event" columnNames="source" />
+            </not>
+        </preConditions>
+        <createIndex indexName="source_idx" tableName="log_event">
+            <column name="source"/>
+        </createIndex>
+    </changeSet>
+
+    <!-- required indexes for log_detail to allow faster/more efficient sorting.-->
+
+    <changeSet author="ALA Dev Team" id="7">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="log_detail" columnNames="entity_type" />
+            </not>
+        </preConditions>
+        <createIndex indexName="entity_type_idx" tableName="log_detail">
+            <column name="entity_type"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="ALA Dev Team" id="8">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="log_detail" columnNames="entity_uid" />
+            </not>
+        </preConditions>
+        <createIndex indexName="entity_uid_idx" tableName="log_detail">
+            <column name="entity_uid"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="ALA Dev Team" id="9">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="log_detail" columnNames="record_count" />
+            </not>
+        </preConditions>
+        <createIndex indexName="record_count_idx" tableName="log_detail">
+            <column name="record_count"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Following https://github.com/AtlasOfLivingAustralia/ala-install/pull/593 and #49 this PR adds `liquibase` support with the new indexes as sample in the changelog.

After boot logger with this PR, the changelog table shows that the indexes were added:

![image](https://user-images.githubusercontent.com/180085/178303719-3deeea69-3ef3-4758-a2a5-7a82130b8134.png)
