### PR TITLE
reduce dev and test db metrics, upgrade aurora

### DIFF
--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -13,7 +13,7 @@ BACKTRACK_WINDOW = 3600
 BACKUP_RETENTION = 1
 CREATE_REPLICA = false
 DB_INSTANCE_NAME = logger-${ENVIRONMENT}
-DB_VERSION = 8.0.mysql_aurora.3.08.2
+DB_VERSION = 8.0.mysql_aurora.3.10.0
 DELETION_PROTECTION = false
 ENGINE_MODE = serverlessv2 # provisioned or serverlessv2
 INSTANCE_CLASS = db.t4g.medium # only used when ENGINE_MODE is provisioned
@@ -34,16 +34,10 @@ AUTO_DEPLOY = true
 # RDS
 DB_INSTANCE_NAME = logger-${CLEAN_BRANCH}
 #RDS_SNAPSHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:ala-logger-database-feature-rds-pipeline-updates-snapshot-dbcluster-wpangbshgwib
-DATABASE_INSIGHTS_MODE = advanced # "standard" or "enhanced"
-PERFORMANCE_INSIGHTS = true # true or false
-ENHANCED_MONITORING = 5 # enhanced monitoring interval in seconds. Set to 0 to disable.
 
 [testing]
 AUTO_DEPLOY = true
 # RDS
-DATABASE_INSIGHTS_MODE = advanced # "standard" or "enhanced"
-PERFORMANCE_INSIGHTS = true # true or false
-ENHANCED_MONITORING = 5 # enhanced monitoring interval in seconds. Set to 0 to disable.
 
 [staging]
 # RDS


### PR DESCRIPTION
The enhanced monitoring on all our dev/testing databases is generating an extra few thousand dollars of CloudWatch usage per year. I think I had this on in my original DB template. The default is not to use enhanced monitoring so I've just removed the config for development and testing environments so we fall back to standard monitoring there. No issues turning back on when we need it but it's expensive to have running all the time. There have been no changes to production monitoring

This also upgrades Aurora MySQL to 3.10.0